### PR TITLE
Fixed mislabeling in unit test and incorrect query for registration

### DIFF
--- a/ProjectSourceCode/src/index.js
+++ b/ProjectSourceCode/src/index.js
@@ -220,7 +220,7 @@ app.post("/registration", async (req, res) => {
 
     //Create new user
     try {
-      await db.none(query, [username, email, hash]);
+      await db.none(createUser, [username, email, hash]);
         console.log("User registered");
         res.status(200).redirect('/login');
     }

--- a/ProjectSourceCode/test/server.spec.js
+++ b/ProjectSourceCode/test/server.spec.js
@@ -81,6 +81,7 @@ describe('Testing Registration API', () => {
   });
 });
 
+
 //EC Testing
 //We are testing the login session by attempting to login using a test user through doing POST /login.
 //Positive case: We are passing valid credentials for an existing user and expect to get a status 200 response and a session to be created.
@@ -109,7 +110,7 @@ describe('Testing Login API', () => {
   // Result: This test case should pass and return a status 400.
   // Explanation: The testcase will call the /login API with the following invalid inputs
   // and expects the API to return a status of 400.
-  it('Negative : /registration, attempts to login to a user with an invalid password', done => {
+  it('Negative : /login, attempts to login to a user with an invalid password', done => {
     chai
       .request(server)
       .post('/login')


### PR DESCRIPTION
Fixed the mislabeling for the negative test case of login which said it was positive. Additionally, fixed the misnamed query that was caused when I added the email and username queries as well.